### PR TITLE
fix: loading static files

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -67,7 +67,7 @@ const responseViaResponseObject = async (
   outgoing: ServerResponse | Http2ServerResponse,
   options: { errorHandler?: CustomErrorHandler } = {}
 ) => {
-  if (res instanceof Promise) {
+  if (res != null && typeof res.then === 'function') {
     if (options.errorHandler) {
       try {
         res = await res


### PR DESCRIPTION
Hi,

I'm working in Angular 19 SSR integration with Hono. While investigating a server crash on the loading of static files, I discovered that it didn't wait for the **res** object to get resolved. The issue is from instanceof Promise. 

`RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: undefined
    at ServerResponse.writeHead (node:_http_server:351:11)
    at Hn (/dist/server/server.mjs:89:11)
    at Server.<anonymous> (/dist/server/server.mjs:91:554)
    at Server.emit (node:events:519:28)
    at parserOnIncoming (node:_http_server:1141:12)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:118:17) {
  code: 'ERR_HTTP_INVALID_STATUS_CODE'
}`